### PR TITLE
Adding new "appearance" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ import LazilyRender from 'react-lazily-render';
 
 The `className` applied to the wrapping element.
 
+#### component
+
+> `string | React.ComponentClass`
+
+The `tagName` of the wrapping element.
+
 ### offset
 
 > `number | {top?: number, right?: number, bottom?: number, left?: number}`

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,6 @@ module.exports = {
     '<rootDir>/node_modules/', //ignore the node_modules
     '<rootDir>/src/_\\.test\\.js$', //ignore the test setup file
   ],
+  verbose: true,
+  testURL: "http://localhost/",
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ declare module 'react-lazily-render' {
 
   export interface LazilyRenderProps {
     className?: string;
+    component?: string | React.ComponentClass;
     offset?: number | {top?: number, right?: number, bottom?: number, left?: number};
     placeholder?: React.ReactNode;
     content?: React.ReactNode;

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import eventListenerOptions from './utils/eventListenerOptions';
 
 export type LazilyRenderProps = {
   className?: string;
+  component?: string | React.ComponentClass;
   offset?: number | {top?: number, right?: number, bottom?: number, left?: number};
   placeholder?: React.Node;
   content?: React.Node;
@@ -26,7 +27,7 @@ export default class LazilyRender extends React.Component<LazilyRenderProps, Laz
 
   raf: ?number;
   element: ?HTMLElement;
-  container: ?HTMLElement | ?Window; 
+  container: ?HTMLElement | ?Window;
 
   state = {
     hasBeenScrolledIntoView: false
@@ -73,11 +74,11 @@ export default class LazilyRender extends React.Component<LazilyRenderProps, Laz
       const elementBounds = this.getElementBounds();
       const viewportBounds = this.getViewportBounds();
       const offsetBounds = this.getOffsetBounds();
-  
+
       if (!elementBounds || !viewportBounds) {
         return;
       }
-  
+
       if (isElementInViewport(elementBounds, viewportBounds, offsetBounds)) {
         this.stopListening();
         this.setState(
@@ -134,12 +135,12 @@ export default class LazilyRender extends React.Component<LazilyRenderProps, Laz
   }
 
   render() {
-    const {className} = this.props;
-    return (
-      <div ref={this.handleMount} className={className}>
-        {this.renderChildren()}
-      </div>
-    );
+    const {className, component} = this.props;
+    return React.createElement(component || 'div', {
+      ref: this.handleMount,
+      className,
+      children: this.renderChildren()
+    });
   }
 
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {mount,shallow} from 'enzyme';
 import LazyRender from '.';
 import {__setViewportBounds} from './utils/getViewportBounds';
 import {__setElementBounds} from './utils/getElementBounds';
@@ -93,6 +93,28 @@ describe('LazyRender', () => {
         </LazyRender>
       );
       expect(wrapper.prop('className')).toEqual('my-cool-class');
+    });
+
+    describe(`when component="span"`, () => {
+      it(`should render the wrapper as <span>`, () => {
+        const wrapper = shallow(
+          <LazyRender component="span">
+            {() => <span>HelloWorld!</span>}
+          </LazyRender>
+        );
+        expect(wrapper.type()).toEqual('span');
+      });
+    });
+
+    describe(`when component="div"`, () => {
+      it(`should render the wrapper as <div>`, () => {
+        const wrapper = shallow(
+          <LazyRender component="div">
+            {() => <span>HelloWorld!</span>}
+          </LazyRender>
+        );
+        expect(wrapper.type()).toEqual('div');
+      });
     });
 
     it('should call the render fn with true when the component is visible in the viewport', () => {
@@ -195,7 +217,7 @@ describe('LazyRender', () => {
           {() => children}
         </LazyRender>
       );
-      
+
       expect(windowAddEventSpy).toBeCalledWith('scroll', expect.anything(), {
         passive: true
       });
@@ -210,13 +232,13 @@ describe('LazyRender', () => {
     it('should listen to the window when scrollparent returns body in CSS1Compat mode', () => {
       mockCompatMode('CSS1Compat');
       mockScrollParent = document.body;
-      
+
       const element = wrapper(
         <LazyRender>
           {() => children}
         </LazyRender>
       );
-      
+
       expect(windowAddEventSpy).toBeCalledWith('scroll', expect.anything(), expect.anything());
       expect(bodyAddEventSpy).not.toBeCalledWith('scroll', expect.anything(), expect.anything());
 
@@ -240,13 +262,13 @@ describe('LazyRender', () => {
       const bodyAddEventSpy = jest.spyOn(document.body, 'addEventListener');
       const windowRemoveEventSpy = jest.spyOn(window, 'removeEventListener');
       const bodyRemoveEventSpy = jest.spyOn(document.body, 'removeEventListener');
-      
+
       const element = wrapper(
         <LazyRender>
           {() => children}
         </LazyRender>
       );
-      
+
       expect(windowAddEventSpy).not.toBeCalledWith('scroll', expect.anything(), expect.anything());
       expect(bodyAddEventSpy).toBeCalledWith('scroll', expect.anything(), expect.anything());
 
@@ -261,7 +283,7 @@ describe('LazyRender', () => {
       expect(bodyRemoveEventSpy).toBeCalledWith('scroll', expect.anything(), expect.anything());
 
       unmockCompatMode();
-    }); 
+    });
 
   });
 


### PR DESCRIPTION
We're using this package to wrap smart cards and we need to be able to specify the appearance of the wrapping element, so that inline cards are not wrapped with `<div>`.