### PR TITLE
feat: added scroll container property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,11 @@ Called to render something depending on whether the component has been scrolled 
 > `() => void`
 
 Called when the component becomes visible for the first time.
+
+#### scrollContainer
+
+> `HTMLElement | undefined`
+
+The container which `react-lazily-render` listens to for scroll events.
+
+This property can be used in a scenario where you want to specify your own scroll container - e.g. if the component you are rendering is asynchronously added to the DOM.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,6 +10,7 @@ declare module 'react-lazily-render' {
     content?: React.ReactNode;
     children?: (render: boolean) => React.ReactNode;
     onRender?: () => void;
+    scrollContainer?: HTMLElement;
   }
 
   export default class LazilyRender extends React.Component<LazilyRenderProps, any> {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ export type LazilyRenderProps = {
   content?: React.Node;
   children?: (render: boolean) => React.Node;
   onRender?: () => void;
+  scrollContainer?: HTMLElement;
 };
 
 export type LazilyRenderState = {
@@ -33,12 +34,20 @@ export default class LazilyRender extends React.Component<LazilyRenderProps, Laz
     hasBeenScrolledIntoView: false
   };
 
-  getContainer(): ?HTMLElement | ?Window {
-    const container = scrollParent(this.element);
-    if (container === document.scrollingElement || container === document.documentElement || (!isBackCompatMode() && container == document.body)) {
-      return window;
+  getContainer(scrollContainer: ?HTMLElement): ?HTMLElement | ?Window {
+    if (scrollContainer) {
+      return scrollContainer;
     } else {
-      return container;
+      if (this.element) {
+        const container = scrollParent(this.element);
+        if (container === document.scrollingElement || container === document.documentElement || (!isBackCompatMode() && container == document.body)) {
+          return window;
+        } else {
+          return container;
+        }
+      } else {
+        return undefined;
+      }
     }
   }
 
@@ -55,14 +64,37 @@ export default class LazilyRender extends React.Component<LazilyRenderProps, Laz
     return convertOffsetToBounds(offset);
   }
 
-  startListening() {
-    const container = this.container;
+  componentDidUpdate(prevProps: ?LazilyRenderProps, prevState: ?LazilyRenderState) {
+    const { scrollContainer: prevContainer } = prevProps;
+    const { scrollContainer: nextContainer } = this.props;
+    // If a scroll container was defined before, do some cleanup
+    // and bootstrap the next scroll container.
+    if (prevContainer !== nextContainer) {
+      // If the previous container was already utilised, no cleanup
+      // is required - already done in LazilyRender.update().
+      if (!prevState.hasBeenScrolledIntoView) {
+        this.stopListening(prevContainer);
+      }
+      // Set a new listener if the scrollContainer is defined, and update 
+      // the container property accordingly. Note: this should only be done
+      // when the next container is different.
+      this.container = this.getContainer(nextContainer);
+      this.startListening(this.container);
+      // Signal that the element has not been scrolled into view and 
+      // recompute its position. This will essentially 'reset' the node's
+      // current status back to a placeholder item if need be.
+      this.setState({ hasBeenScrolledIntoView: false }, () => {
+        this.update();
+      });
+    }
+  }
+
+  startListening(container: ?HTMLElement) {
     if (container) container.addEventListener('scroll', this.update, eventListenerOptions);
     window.addEventListener('resize', this.update);
   }
 
-  stopListening() {
-    const container = this.container;
+  stopListening(container: ?HTMLElement) {
     if (container) container.removeEventListener('scroll', this.update, eventListenerOptions);
     window.removeEventListener('resize', this.update);
   }
@@ -80,7 +112,7 @@ export default class LazilyRender extends React.Component<LazilyRenderProps, Laz
       }
 
       if (isElementInViewport(elementBounds, viewportBounds, offsetBounds)) {
-        this.stopListening();
+        this.stopListening(this.container);
         this.setState(
           {
             hasBeenScrolledIntoView: true
@@ -98,21 +130,18 @@ export default class LazilyRender extends React.Component<LazilyRenderProps, Laz
   }
 
   handleMount = (element: ?HTMLElement) => {
+    const { scrollContainer } = this.props;
     this.element = element;
-    if (this.element) {
-      this.container = this.getContainer();
-    } else {
-      this.container = undefined;
-    }
+    this.container = this.getContainer(scrollContainer);
   }
 
   componentDidMount() {
     this.update();
-    this.startListening();
+    this.startListening(this.container);
   }
 
   componentWillUnmount() {
-    this.stopListening();
+    this.stopListening(this.container);
   }
 
   renderChildren() {


### PR DESCRIPTION
## Context

We have been running into a situation with Smart Links (ha!) whereby the component being passed to `<LazilyRender />` through the `content` property is not in the DOM on first render. This is occurring due to asynchronous rendering of the component being passed to `LazilyRender`.

## Issues caused
As a consequence of the above, the computation of the scroll container via. `scrollParent()` is resolving to the top-level `<html>` tag in the DOM, since the current component cannot be found in the DOM. 

In scenarios, when content is inserted within a scroll container - in this case the AtlasKit Fabric Editor - unexpected behaviour results. I.e. rather than listening to scroll events on the _actual_ parent of the inserted node (the AK Editor), `LazilyRender` is listening to the incorrect container for scroll events.

This is leading to components which are wrapped in `LazilyRender` to not transition to their actual `content` when they are scrolled into the viewport within their _actual_ scroll container.

## Proposed solution
Introduce an explicit but optional `scrollContainer` property, which defines lazy loading behaviours and assists in computing the DOM ancestry for child components which are being asynchronously rendered. With an increasing move toward asynchronous rendering of components, I believe this API will future-proof `react-lazily-render` at large as well.

###### NOTE:

A quick note that introducing a `setTimeout()` on the internals of `this.handleMount()` made things work for our component, and triggered lazy rendering as expected when our component was scrolled into the viewport. This helped testify the asynchronous nature of the rendering pathway 🚀 

The solution I am suggesting here is partly what `react-lazyload` have attempted to do by exposing an optional container property visible [here](https://github.com/twobin/react-lazyload/blob/master/src/index.jsx#L291).

cc/ @zzarcon who paired with me on these issues. 

(also, 👋 @jameslnewell!)
