### PR TITLE
Update `react` peerDependency in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazily-render",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Lazily render react components",
   "keywords": [
     "react",
@@ -26,7 +26,7 @@
     "scrollparent": "^2.0.1"
   },
   "peerDependencies": {
-    "react": "^16.1.1"
+    "react": "^16.1.1 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",


### PR DESCRIPTION
Installing `react-lazily-render` in a project using React 17 or 18 fails with the following error:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: marcnitzsche.de@0.1.0
npm ERR! Found: react@18.0.0
npm ERR! node_modules/react
npm ERR!   react@"18.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.1.1" from react-lazily-render@1.2.0
npm ERR! node_modules/react-lazily-render
npm ERR!   react-lazily-render@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

A workaround is using `npm install react-lazily-render --force` which works without problems. As the package is working in newer React versions already, I propose updating its peer dependencies. Generally, though, we should re-run the tests against the newer versions of React to see if anything breaks.